### PR TITLE
User/westberg/no op transformer for child bindings

### DIFF
--- a/HierarchicalDataConverter/Catalyst.HierarchicalDataConverter/Catalyst.HierarchicalDataConverter.csproj
+++ b/HierarchicalDataConverter/Catalyst.HierarchicalDataConverter/Catalyst.HierarchicalDataConverter.csproj
@@ -219,12 +219,14 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BindingReference.cs" />
+    <Compile Include="ChildBindingNoOpDataTransformer.cs" />
     <Compile Include="HierarchicalConfiguration.cs" />
     <Compile Include="HierarchicalDataTransformer.cs" />
     <Compile Include="HmacAuthorizationRequestInterceptor.cs" />
     <Compile Include="IClientSpecificConfiguration.cs" />
     <Compile Include="LoggingHelper2.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RestApiDestinationSystem.cs" />
     <Compile Include="UpmcSpecificConfig.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/HierarchicalDataConverter/Catalyst.HierarchicalDataConverter/ChildBindingNoOpDataTransformer.cs
+++ b/HierarchicalDataConverter/Catalyst.HierarchicalDataConverter/ChildBindingNoOpDataTransformer.cs
@@ -20,6 +20,11 @@
 
         public bool CanHandle(BindingExecution bindingExecution, Binding binding, Entity destinationEntity)
         {
+            if (binding == null)
+            {
+                throw new ArgumentException("Binding cannot be null.");
+            }
+
             return binding.BindingType == HierarchicalDataTransformer.NestedBindingTypeName;
         }
     }

--- a/HierarchicalDataConverter/Catalyst.HierarchicalDataConverter/ChildBindingNoOpDataTransformer.cs
+++ b/HierarchicalDataConverter/Catalyst.HierarchicalDataConverter/ChildBindingNoOpDataTransformer.cs
@@ -1,0 +1,23 @@
+﻿namespace DataConverter
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    using Catalyst.DataProcessing.Engine.PluginInterfaces;
+    using Catalyst.DataProcessing.Shared.Models.DataProcessing;
+    using Catalyst.DataProcessing.Shared.Models.Metadata;
+
+    public class ChildBindingNoOpDataTransformer : IDataTransformer
+    {
+        public async Task<long> TransformDataAsync(BindingExecution bindingExecution, Binding binding, Entity entity, CancellationToken cancellationToken)
+        {
+            return Convert.ToInt64(0);
+        }
+
+        public bool CanHandle(BindingExecution bindingExecution, Binding binding, Entity destinationEntity)
+        {
+            return binding.BindingType == HierarchicalDataTransformer.NestedBindingTypeName;
+        }
+    }
+}

--- a/HierarchicalDataConverter/Catalyst.HierarchicalDataConverter/ChildBindingNoOpDataTransformer.cs
+++ b/HierarchicalDataConverter/Catalyst.HierarchicalDataConverter/ChildBindingNoOpDataTransformer.cs
@@ -8,6 +8,9 @@
     using Catalyst.DataProcessing.Shared.Models.DataProcessing;
     using Catalyst.DataProcessing.Shared.Models.Metadata;
 
+    /// <summary>
+    /// All Child (non-root) "Nested" type bindings are handled as part of the HierarchicalDataTransformer, even though that transformer only picks up the root.
+    /// </summary>
     public class ChildBindingNoOpDataTransformer : IDataTransformer
     {
         public async Task<long> TransformDataAsync(BindingExecution bindingExecution, Binding binding, Entity entity, CancellationToken cancellationToken)

--- a/HierarchicalDataConverter/Catalyst.HierarchicalDataConverter/HierarchicalDataTransformer.cs
+++ b/HierarchicalDataConverter/Catalyst.HierarchicalDataConverter/HierarchicalDataTransformer.cs
@@ -37,7 +37,7 @@ namespace DataConverter
     /// </summary>
     public class HierarchicalDataTransformer : IDataTransformer
     {
-        private const string NestedBindingTypeName = "Nested";
+        public const string NestedBindingTypeName = "Nested";
         private const string SourceEntitySourceColumnSeparator = "__";
 
         private readonly IMetadataServiceClient metadataServiceClient;
@@ -98,6 +98,7 @@ namespace DataConverter
             catch (Exception e)
             {
                 LoggingHelper2.Debug($"TransformDataAsync Threw exception: {e}");
+                throw;
             }
 
             return Convert.ToInt64(1);

--- a/HierarchicalDataConverter/Catalyst.HierarchicalDataConverter/LoggingHelper2.cs
+++ b/HierarchicalDataConverter/Catalyst.HierarchicalDataConverter/LoggingHelper2.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.IO;
-    using Catalyst.DataProcessing.Shared.Utilities.Logging;
 
     public class LoggingHelper2
     {
@@ -19,7 +18,6 @@
             {
                 lock (threadlock)
                 {
-                    // LoggingHelper.Debug(message); // This is no longer working for some reason
                     // TODO - create plugin specific log
                     File.AppendAllText(
                         $@"C:\Program Files\Health Catalyst\Data-Processing Engine\logs\DataProcessingEngine_PluginOnly.log",

--- a/HierarchicalDataConverter/Catalyst.HierarchicalDataConverter/RestApiDestinationSystem.cs
+++ b/HierarchicalDataConverter/Catalyst.HierarchicalDataConverter/RestApiDestinationSystem.cs
@@ -37,6 +37,12 @@
             }
 
             Binding[] bindings = this.metadataServiceClient.GetBindingsForEntityAsync(entity.Id).Result;
+
+            if (bindings == null)
+            {
+                return false;
+            }
+
             return bindings.Any(b => b.BindingType == HierarchicalDataTransformer.NestedBindingTypeName);
         }
 

--- a/HierarchicalDataConverter/Catalyst.HierarchicalDataConverter/RestApiDestinationSystem.cs
+++ b/HierarchicalDataConverter/Catalyst.HierarchicalDataConverter/RestApiDestinationSystem.cs
@@ -31,6 +31,11 @@
 
         public bool CanHandle(Entity entity)
         {
+            if (entity == null)
+            {
+                throw new ArgumentException("Entity cannot be null.");
+            }
+
             Binding[] bindings = this.metadataServiceClient.GetBindingsForEntityAsync(entity.Id).Result;
             return bindings.Any(b => b.BindingType == HierarchicalDataTransformer.NestedBindingTypeName);
         }

--- a/HierarchicalDataConverter/Catalyst.HierarchicalDataConverter/RestApiDestinationSystem.cs
+++ b/HierarchicalDataConverter/Catalyst.HierarchicalDataConverter/RestApiDestinationSystem.cs
@@ -1,0 +1,59 @@
+﻿namespace DataConverter
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    using Catalyst.DataProcessing.Engine.PluginInterfaces;
+    using Catalyst.DataProcessing.Shared.Models.DataProcessing;
+    using Catalyst.DataProcessing.Shared.Models.Metadata;
+    using Catalyst.DataProcessing.Shared.Utilities.Client;
+
+    public class RestApiDestinationSystem : IDestinationSystem
+    {
+        private readonly IMetadataServiceClient metadataServiceClient;
+
+        public RestApiDestinationSystem(IMetadataServiceClient metadataServiceClient)
+        {
+            this.metadataServiceClient = metadataServiceClient ?? throw new ArgumentException("metadataServiceClient cannot be null.");
+        }
+
+        public async Task AddEntityOptimizationsAsync(EntityExecution entityExecution, Entity entity, DataMart dataMart, CancellationToken cancellationToken)
+        {
+            // no op
+            return;
+        }
+
+        public bool CanHandle(Entity entity)
+        {
+            Binding[] bindings = this.metadataServiceClient.GetBindingsForEntityAsync(entity.Id).Result;
+            return bindings.Any(b => b.BindingType == HierarchicalDataTransformer.NestedBindingTypeName);
+        }
+
+        public async Task CreateDestinationEntityAsync(EntityExecution entityExecution, Entity entity, DataMart dataMart, CancellationToken cancellationToken)
+        {
+            // no op
+            return;
+        }
+
+        public async Task CreatePhysicalEntityAsync(EntityExecution entityExecution, Entity entity, DataMart dataMart, CancellationToken cancellationToken)
+        {
+            // no op
+            return;
+        }
+
+        public Task<IDictionary<string, object>> GetExampleDataAsync(EntityExecution entityExecution, Entity entity, ICollection<Field> fieldsToUpdate, CancellationToken cancellationToken)
+        {
+            IDictionary<string, object> result = new Dictionary<string, object>();
+            return Task.FromResult(result);
+        }
+
+        public async Task<long> PromoteStagedDataAsync(EntityExecution entityExecution, Entity entity, DataMart dataMart, CancellationToken cancellationToken)
+        {
+            // no op: Databus takes care of this
+            return Convert.ToInt64(0);
+        }
+    }
+}

--- a/HierarchicalDataConverter/Catalyst.HierarchicalDataConverter/RestApiDestinationSystem.cs
+++ b/HierarchicalDataConverter/Catalyst.HierarchicalDataConverter/RestApiDestinationSystem.cs
@@ -11,6 +11,9 @@
     using Catalyst.DataProcessing.Shared.Models.Metadata;
     using Catalyst.DataProcessing.Shared.Utilities.Client;
 
+    /// <summary>
+    /// Databus currently handles the promotion of data to its final destination (Rest API), therefore this is a no op implementation
+    /// </summary>
     public class RestApiDestinationSystem : IDestinationSystem
     {
         private readonly IMetadataServiceClient metadataServiceClient;


### PR DESCRIPTION
Added a no-op IDataTransformer for child bindings (non-root) so the engine doesn't assign them a default data transformer and try to work on them.

Added a no-op IDestinationSystem for Restful APIs so that the engine will ignore them too, instead of trying to promote staged data the sql way.

Added re-throw in TransformDataAsync catch.

With these changes, a properly set up Nested binding should show "Succeeded" in EDW Console.