### PR TITLE
Minor Incremental Fix

### DIFF
--- a/HierarchicalDataConverter/Catalyst.HierarchicalDataConverter/HierarchicalDataTransformer.cs
+++ b/HierarchicalDataConverter/Catalyst.HierarchicalDataConverter/HierarchicalDataTransformer.cs
@@ -392,7 +392,7 @@ namespace DataConverter
 
             var incrementalColumns = new List<IncrementalColumn>();
 
-            if (binding.LoadTypeCode != BindingLoadType.Incremental)
+            if (bindingExecution.LoadType != BindingLoadType.Incremental)
             {
                 return incrementalColumns;
             }

--- a/HierarchicalDataConverter/Catalyst.HierarchicalDataConverter/HierarchicalDataTransformer.cs
+++ b/HierarchicalDataConverter/Catalyst.HierarchicalDataConverter/HierarchicalDataTransformer.cs
@@ -387,6 +387,11 @@ namespace DataConverter
 
             var incrementalColumns = new List<IncrementalColumn>();
 
+            if (binding.LoadTypeCode != BindingLoadType.Incremental)
+            {
+                return incrementalColumns;
+            }
+
             if (binding.IncrementalConfigurations.Count == 0)
             {
                 return incrementalColumns;


### PR DESCRIPTION
add check for `binding.LoadType` == `Incremental` before adding incremental values. 
Without this, it won't honor the `LoadType` and will run incremental if it finds an incremental configuration - even if the binding is set to `Full`
Before this change it would run incremental even if load type was full, so long as it found an incremental config for the binding.
This should fix that so that you can set a binding to `Full` without having to delete any existing `IncrementalConfiguration`